### PR TITLE
Remove deploy to kubernetes step

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -14,10 +14,3 @@ build:
         tag: $WERCKER_GIT_COMMIT, $WERCKER_GIT_BRANCH, latest
         entrypoint: python
         cmd: -u /docker-entrypoint.py
-deploy-to-kubernetes:
-  steps:
-    - kubectl:
-        server: $KUBERNETES_MASTER
-        token: $KUBERNETES_TOKEN
-        insecure-skip-tls-verify: true
-        command: set image -n kube-system daemonset spot-price-monitor spot-price-monitor=112622444253.dkr.ecr.us-east-1.amazonaws.com/pusher/spot-price-monitor:$WERCKER_GIT_COMMIT


### PR DESCRIPTION
We don't ever actually use this, so it doesn't need to be there