### PR TITLE
Include `Linux/UNIX (Amazon VPC)` products

### DIFF
--- a/spot-price-monitor.py
+++ b/spot-price-monitor.py
@@ -41,7 +41,7 @@ def get_spot_prices(client, instance_types, availability_zones):
         ],
         InstanceTypes=instance_types,
         StartTime=datetime.now(),
-        ProductDescriptions=['Linux/UNIX']
+        ProductDescriptions=['Linux/UNIX', 'Linux/UNIX (Amazon VPC)']
     )
     return response['SpotPriceHistory']
 


### PR DESCRIPTION
It seems like the instance types we are using (`c4`) are only available with this product descriptions.  Otherwise this only returns spot prices for older instance types.