### PR TITLE
This change adds ondemand prices

### DIFF
--- a/spot-price-monitor.py
+++ b/spot-price-monitor.py
@@ -115,7 +115,7 @@ def get_args():
     parser.add_argument('-r', '--region', type=str, default='us-east-1',
                         help='''The region that the cluster is running
                         in (Default: us-east-1)''')
-    parser.add_argument('-o', '--ondemand', action="store_true", default=False,
+    parser.add_argument('--ondemand', action="store_true", default=False,
                         help='''Will enable ondemand prices''')
     parser.add_argument('-v', '--verbose', action="store_true", default=False,
                         help='''Enable verbose output''')
@@ -184,6 +184,7 @@ if __name__ == '__main__':
 
     last_ondemand_update = 0
     backoff_multiplier = 1
+    spot_prices = []
     while(True):
         zones = get_zones_from_k8s(v1)
         try:

--- a/spot-price-monitor.py
+++ b/spot-price-monitor.py
@@ -197,7 +197,7 @@ if __name__ == '__main__':
                 backoff_multiplier *= 2
         update_spot_price_metrics(s, spot_prices)
 
-        # refresh ondemand prices each hour
+        # refresh ondemand prices each day
         if args.ondemand and last_ondemand_update+86400<time.time():
             try:
                 last_ondemand_update = time.time()

--- a/spot-price-monitor.py
+++ b/spot-price-monitor.py
@@ -200,8 +200,13 @@ if __name__ == '__main__':
         if args.ondemand and last_ondemand_update+86400<time.time():
             try:
                 last_ondemand_update = time.time()
+                price_zones = {}
+                price_instance_types = {}
+                for price in spot_prices:
+                    price_zones[price['AvailabilityZone']]=1
+                    price_instance_types[price['InstanceType']]=1
                 ondemand_prices=get_ondemand_price_metrics()
-                update_ondemand_price_metrics(o, ondemand_prices, types, zones)
+                update_ondemand_price_metrics(o, ondemand_prices, price_instance_types.keys(), price_zones.keys())
             except Exception as e:
                 logging.error("Ondemand prices load failed. I won't retry for another day. Error: %s" % e.message)
                 error.labels(code='ondemand_failure').inc()


### PR DESCRIPTION
Most of the time when using spot prices you want to compare them to the ondemand cost for alerting and graphing.

Unfortunately aws does not provide an api for getting ondemand costs. In order for this to work I am pulling from https://raw.githubusercontent.com/powdahound/ec2instances.info/master/www/instances.json. This is the backend data from ec2instances.info. As this might not be 100% reliable I have only enabled this via a command line option which is off by default.

It is only updated once every 24 hours.

This change also adds logging and a verbose option.

I haven't deployed this to our environment yet. Only tested it locally. I thought I'd get your thoughts on this early.